### PR TITLE
Optimize train

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -275,7 +275,8 @@ function feval(x)
         clones.rnn[t]:training() -- make sure we are in correct mode (this is cheap, sets flag)
         local lst = clones.rnn[t]:forward{x[t], unpack(rnn_state[t-1])}
         rnn_state[t] = {}
-        for i=1,#init_state do rnn_state[t][#rnn_state[t]+1] = lst[i] end -- extract the state, without output
+        rnn_state[t][#init_state] = 0 -- Set up the array at this size
+        for i=1,#init_state do rnn_state[t][i] = lst[i] end -- extract the state, without output
         predictions[t] = lst[#lst] -- last element is the prediction
         loss = loss + clones.criterion[t]:forward(predictions[t], y[t])
     end

--- a/train.lua
+++ b/train.lua
@@ -243,7 +243,7 @@ function eval_split(split_index, max_batches)
             clones.rnn[t]:evaluate() -- for dropout proper functioning
             local lst = clones.rnn[t]:forward{x[t], unpack(rnn_state[t-1])}
             rnn_state[t] = {}
-            for i=1,#init_state do table.insert(rnn_state[t], lst[i]) end
+            for i=1,#init_state do rnn_state[t][#rnn_state[t]+1] = lst[i] end
             prediction = lst[#lst] 
             loss = loss + clones.criterion[t]:forward(prediction, y[t])
         end

--- a/train.lua
+++ b/train.lua
@@ -369,8 +369,9 @@ for i = 1, iterations do
         print('loss is NaN.  This usually indicates a bug.  Please check the issues page for existing issues, or create a new issue, if none exist.  Ideally, please state: your operating system, 32-bit/64-bit, your blas version, cpu/cuda/cl?')
         break -- halt
     end
-    if loss0 == nil then loss0 = loss[1] end
-    if loss[1] > loss0 * 3 then
+    if loss0 == nil then
+        loss0 = loss[1]
+    elseif loss[1] > loss0 * 3 then
         print('loss is exploding, aborting.')
         break -- halt
     end

--- a/train.lua
+++ b/train.lua
@@ -274,8 +274,7 @@ function feval(x)
     for t=1,opt.seq_length do
         clones.rnn[t]:training() -- make sure we are in correct mode (this is cheap, sets flag)
         local lst = clones.rnn[t]:forward{x[t], unpack(rnn_state[t-1])}
-        rnn_state[t] = {}
-        for i=1,#init_state do rnn_state[t][i] = lst[i] end -- extract the state, without output
+        rnn_state[t] = {unpack(lst, i, #init_state)} -- extract the state, without output
         predictions[t] = lst[#lst] -- last element is the prediction
         loss = loss + clones.criterion[t]:forward(predictions[t], y[t])
     end

--- a/train.lua
+++ b/train.lua
@@ -294,8 +294,8 @@ function feval(x)
     end
     ------------------------ misc ----------------------
     -- transfer final state to initial state (BPTT)
-    init_state_global = rnn_state[#rnn_state] -- NOTE: I don't think this needs to be a clone, right?
-    -- grad_params:div(opt.seq_length) -- this line should be here but since we use rmsprop it would have no effect. Removing for efficiency
+    -- NOTE: line below actually needs a clone. Otherwise, at t=1 during the backpropagation, rnn_state[0] will be equal to the init_state_global of the next batch, different than the one used in the forward
+    init_state_global = clone_list(rnn_state[#rnn_state])
     -- clip gradient element-wise
     grad_params:clamp(-opt.grad_clip, opt.grad_clip)
     return loss, grad_params

--- a/train.lua
+++ b/train.lua
@@ -275,7 +275,7 @@ function feval(x)
         clones.rnn[t]:training() -- make sure we are in correct mode (this is cheap, sets flag)
         local lst = clones.rnn[t]:forward{x[t], unpack(rnn_state[t-1])}
         rnn_state[t] = {}
-        for i=1,#init_state do table.insert(rnn_state[t], lst[i]) end -- extract the state, without output
+        for i=1,#init_state do rnn_state[t][#rnn_state[t]+1] = lst[i] end -- extract the state, without output
         predictions[t] = lst[#lst] -- last element is the prediction
         loss = loss + clones.criterion[t]:forward(predictions[t], y[t])
     end
@@ -286,7 +286,7 @@ function feval(x)
     for t=opt.seq_length,1,-1 do
         -- backprop through loss, and softmax/linear
         local doutput_t = clones.criterion[t]:backward(predictions[t], y[t])
-        table.insert(drnn_state[t], doutput_t)
+        drnn_state[t][#drnn_state[t]+1] = doutput_t
         local dlst = clones.rnn[t]:backward({x[t], unpack(rnn_state[t-1])}, drnn_state[t])
         drnn_state[t-1] = {}
         for k,v in pairs(dlst) do

--- a/train.lua
+++ b/train.lua
@@ -275,7 +275,6 @@ function feval(x)
         clones.rnn[t]:training() -- make sure we are in correct mode (this is cheap, sets flag)
         local lst = clones.rnn[t]:forward{x[t], unpack(rnn_state[t-1])}
         rnn_state[t] = {}
-        rnn_state[t][#init_state] = 0 -- Set up the array at this size
         for i=1,#init_state do rnn_state[t][i] = lst[i] end -- extract the state, without output
         predictions[t] = lst[#lst] -- last element is the prediction
         loss = loss + clones.criterion[t]:forward(predictions[t], y[t])

--- a/train.lua
+++ b/train.lua
@@ -287,14 +287,9 @@ function feval(x)
         local doutput_t = clones.criterion[t]:backward(predictions[t], y[t])
         drnn_state[t][#drnn_state[t]+1] = doutput_t
         local dlst = clones.rnn[t]:backward({x[t], unpack(rnn_state[t-1])}, drnn_state[t])
-        drnn_state[t-1] = {}
-        for k,v in pairs(dlst) do
-            if k > 1 then -- k == 1 is gradient on x, which we dont need
-                -- note we do k-1 because first item is dembeddings, and then follow the 
-                -- derivatives of the state, starting at index 2. I know...
-                drnn_state[t-1][k-1] = v
-            end
-        end
+        -- dlst[1] is the gradient on x, which we don't need
+        -- using unpack should slide the values into the correct indexes, allowing us to forego a loop.
+        drnn_state[t-1] = {unpack(dlst, 2)}
     end
     ------------------------ misc ----------------------
     -- transfer final state to initial state (BPTT)


### PR DESCRIPTION
Based on my testing, I think I have managed to reduce the time it takes for a batch to complete by 5%-ish. I removed the most frequently-called uses of table.insert() and instead referenced the addresses directly. For the rnn_size[t] table in feval(), I also set the array to be sized once instead of as it goes along.
On my (aging) hardware, this is shaving a second or two off each batch time.

Given my train loss did not differ between trial runs on my computer, I think the behavior is identical to the previous behavior.